### PR TITLE
Add airline-focused async policy tests with timeout liveness validation and completion-order nondeterminism

### DIFF
--- a/src/main/java/AsyncProcessor.java
+++ b/src/main/java/AsyncProcessor.java
@@ -2,11 +2,21 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 //AsyncProcessor.java: coordinates many microservice futures.
 
 public class AsyncProcessor {
+
+        private static final long PER_SERVICE_TIMEOUT_MS = 500;
+
+        private CompletableFuture<String> timedRetrieve(Microservice client, String message) {
+                // Enforce liveness: a hanging service cannot block aggregation forever.
+                return client.retrieveAsync(message)
+                                .orTimeout(PER_SERVICE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        }
 
         // // processAsync: output order follows input list order (because you stream
         // // futures in list order after all complete).
@@ -17,14 +27,11 @@ public class AsyncProcessor {
                                         new IllegalArgumentException("Services and messages size mismatch"));
                 }
 
-                List<CompletableFuture<String>> futures = microservices.stream()
-                                .map(client -> client.retrieveAsync(messages.get(microservices.indexOf(client))))
-                                .collect(Collectors.toList()); // collect(toList()) just gathers those
+                List<CompletableFuture<String>> futures = IntStream.range(0, microservices.size())
+                                .mapToObj(i -> timedRetrieve(microservices.get(i), messages.get(i)))
+                                .collect(Collectors.toList());
 
-                // wait for them to complete.
-
-                return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])) // allOf(...) = “wait until
-                                                                                          // all futures are done.”
+                return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
                                 .thenApply(v -> futures.stream()
                                                 .map(CompletableFuture::join)
                                                 .collect(Collectors.joining(" ")));
@@ -38,23 +45,19 @@ public class AsyncProcessor {
                                         new IllegalArgumentException("Services and messages size mismatch"));
                 }
 
-                List<CompletableFuture<String>> futures = microservices.stream()
-                                .map(client -> client.retrieveAsync(messages.get(microservices.indexOf(client)))
+                List<CompletableFuture<String>> futures = IntStream.range(0, microservices.size())
+                                .mapToObj(i -> timedRetrieve(microservices.get(i), messages.get(i))
                                                 .exceptionally((ex) -> {
                                                         System.err.println("[FailPartial] Service failed: "
                                                                         + ex.getMessage());
                                                         return null;
                                                 }))
+                                .collect(Collectors.toList());
 
-                                .collect(Collectors.toList()); // collect(toList()) just gathers those
-
-                // wait for them to complete.
-
-                return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])) // allOf(...) = “wait until
-                                                                                          // all futures are done.”
+                return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
                                 .thenApply(v -> futures.stream()
                                                 .map(CompletableFuture::join)
-                                                .filter(result -> result != null) // skip failed services
+                                                .filter(result -> result != null)
                                                 .collect(Collectors.toList()));
 
         }
@@ -67,19 +70,16 @@ public class AsyncProcessor {
                                         new IllegalArgumentException("Services and messages size mismatch"));
                 }
 
-                List<CompletableFuture<String>> futures = microservices.stream()
-                                .map(client -> client.retrieveAsync(messages.get(microservices.indexOf(client)))
+                List<CompletableFuture<String>> futures = IntStream.range(0, microservices.size())
+                                .mapToObj(i -> timedRetrieve(microservices.get(i), messages.get(i))
                                                 .exceptionally((ex) -> {
                                                         System.err.println("[FailSoft] Service failed: "
                                                                         + ex.getMessage());
                                                         return fallbackValue;
                                                 }))
-                                .collect(Collectors.toList()); // collect(toList()) just gathers those
+                                .collect(Collectors.toList());
 
-                // wait for them to complete.
-
-                return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])) // allOf(...) = “wait until
-                                                                                          // all futures are done.”
+                return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
                                 .thenApply(v -> futures.stream()
                                                 .map(CompletableFuture::join)
                                                 .collect(Collectors.joining(" ")));
@@ -89,15 +89,13 @@ public class AsyncProcessor {
         // In processAsyncCompletionOrder, each future adds to a synchronized list when
         // it completes
         // so list order is fastest-first (non-deterministic).
-        // processAsyncCompletionOrder: order changes run-to-run because of random
-        // delays.
         public CompletableFuture<List<String>> processAsyncCompletionOrder(
                         List<Microservice> microservices, String message) {
 
                 List<String> completionOrder = Collections.synchronizedList(new ArrayList<>());
 
                 List<CompletableFuture<Void>> futures = microservices.stream()
-                                .map(ms -> ms.retrieveAsync(message)
+                                .map(ms -> timedRetrieve(ms, message)
                                                 .thenAccept(completionOrder::add))
                                 .collect(Collectors.toList());
 

--- a/src/test/java/AsyncProcessor_Airline_Test.java
+++ b/src/test/java/AsyncProcessor_Airline_Test.java
@@ -1,0 +1,291 @@
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("AsyncProcessor - Airline Quote Policies (no Mockito)")
+public class AsyncProcessor_Airline_Test {
+
+    private AsyncProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new AsyncProcessor();
+    }
+
+    @Test
+    @DisplayName("FailFast: all airline quote services succeed")
+    void failFast_allSuccess(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                new Microservice("AirAlpha"),
+                new Microservice("JetBravo"),
+                new Microservice("SkyCharlie"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo", "nyc-sea");
+
+        String actual = processor.processAsyncFailFast(services, messages).join();
+        String expected = "AirAlpha:NYC-LAX JetBravo:NYC-SFO SkyCharlie:NYC-SEA";
+
+        logExpectedActual(reporter, "failFast_allSuccess", expected, actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("FailFast: one airline API fails, whole request fails")
+    void failFast_oneFails(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                failingService("AirAlpha", "AirAlpha API down"),
+                new Microservice("JetBravo"),
+                new Microservice("SkyCharlie"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo", "nyc-sea");
+
+        CompletionException ex = assertThrows(
+                CompletionException.class,
+                () -> processor.processAsyncFailFast(services, messages).join());
+
+        Throwable root = rootCause(ex);
+        logExpectedActual(reporter, "failFast_oneFails", "RuntimeException containing 'AirAlpha API down'",
+                root.getClass().getSimpleName() + ": " + root.getMessage());
+        assertTrue(root instanceof RuntimeException);
+        assertTrue(root.getMessage().contains("AirAlpha API down"));
+    }
+
+    @Test
+    @DisplayName("FailFast: size mismatch throws IllegalArgumentException")
+    void failFast_sizeMismatch(TestReporter reporter) {
+        List<Microservice> services = List.of(new Microservice("AirAlpha"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo");
+
+        CompletionException ex = assertThrows(
+                CompletionException.class,
+                () -> processor.processAsyncFailFast(services, messages).join());
+
+        Throwable root = rootCause(ex);
+        logExpectedActual(reporter, "failFast_sizeMismatch", "IllegalArgumentException",
+                root.getClass().getSimpleName() + ": " + root.getMessage());
+        assertTrue(root instanceof IllegalArgumentException);
+    }
+
+    @Test
+    @DisplayName("FailFast Liveness: hanging service times out and does not block forever")
+    void failFast_liveness_timeout(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                hangingService("StuckAir"),
+                new Microservice("JetBravo"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo");
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+            CompletionException ex = assertThrows(
+                    CompletionException.class,
+                    () -> processor.processAsyncFailFast(services, messages).join());
+            Throwable root = rootCause(ex);
+            logExpectedActual(reporter, "failFast_liveness_timeout", "TimeoutException",
+                    root.getClass().getSimpleName());
+            assertTrue(root instanceof TimeoutException);
+        });
+    }
+
+    @Test
+    @DisplayName("FailPartial: all airline quotes succeed")
+    void failPartial_allSuccess(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                new Microservice("AirAlpha"),
+                new Microservice("JetBravo"),
+                new Microservice("SkyCharlie"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo", "nyc-sea");
+
+        List<String> actual = processor.processAsyncFailPartial(services, messages).join();
+        List<String> expected = List.of(
+                "AirAlpha:NYC-LAX",
+                "JetBravo:NYC-SFO",
+                "SkyCharlie:NYC-SEA");
+
+        logExpectedActual(reporter, "failPartial_allSuccess", expected, actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("FailPartial: failed airline quote is excluded")
+    void failPartial_oneFails(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                failingService("AirAlpha", "AirAlpha timeout"),
+                new Microservice("JetBravo"),
+                new Microservice("SkyCharlie"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo", "nyc-sea");
+
+        List<String> actual = processor.processAsyncFailPartial(services, messages).join();
+        List<String> expected = List.of("JetBravo:NYC-SFO", "SkyCharlie:NYC-SEA");
+
+        logExpectedActual(reporter, "failPartial_oneFails", expected, actual);
+        assertEquals(2, actual.size());
+        assertTrue(actual.contains("JetBravo:NYC-SFO"));
+        assertTrue(actual.contains("SkyCharlie:NYC-SEA"));
+        assertFalse(actual.contains(null));
+    }
+
+    @Test
+    @DisplayName("FailPartial: all airline APIs fail -> empty result list")
+    void failPartial_allFail(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                failingService("AirAlpha", "AirAlpha down"),
+                failingService("JetBravo", "JetBravo down"),
+                failingService("SkyCharlie", "SkyCharlie down"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo", "nyc-sea");
+
+        List<String> actual = processor.processAsyncFailPartial(services, messages).join();
+        List<String> expected = List.of();
+
+        logExpectedActual(reporter, "failPartial_allFail", expected, actual);
+        assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    @DisplayName("FailPartial Liveness: hanging service gets dropped after timeout")
+    void failPartial_liveness_timeout(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                hangingService("StuckAir"),
+                new Microservice("JetBravo"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo");
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+            List<String> actual = processor.processAsyncFailPartial(services, messages).join();
+            List<String> expected = List.of("JetBravo:NYC-SFO");
+            logExpectedActual(reporter, "failPartial_liveness_timeout", expected, actual);
+            assertEquals(1, actual.size());
+            assertEquals("JetBravo:NYC-SFO", actual.get(0));
+        });
+    }
+
+    @Test
+    @DisplayName("FailSoft: all airline quote services succeed")
+    void failSoft_allSuccess(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                new Microservice("AirAlpha"),
+                new Microservice("JetBravo"),
+                new Microservice("SkyCharlie"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo", "nyc-sea");
+
+        String actual = processor
+                .processAsyncFailSoft(services, messages, "QUOTE_UNAVAILABLE")
+                .join();
+        String expected = "AirAlpha:NYC-LAX JetBravo:NYC-SFO SkyCharlie:NYC-SEA";
+
+        logExpectedActual(reporter, "failSoft_allSuccess", expected, actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("FailSoft: failed airline quote replaced with fallback")
+    void failSoft_oneFails(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                new Microservice("AirAlpha"),
+                failingService("JetBravo", "JetBravo timeout"),
+                new Microservice("SkyCharlie"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo", "nyc-sea");
+
+        String actual = processor
+                .processAsyncFailSoft(services, messages, "QUOTE_UNAVAILABLE")
+                .join();
+        String expected = "AirAlpha:NYC-LAX QUOTE_UNAVAILABLE SkyCharlie:NYC-SEA";
+
+        logExpectedActual(reporter, "failSoft_oneFails", expected, actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("FailSoft: all airline APIs fail but caller still gets result")
+    void failSoft_allFail(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                failingService("AirAlpha", "AirAlpha down"),
+                failingService("JetBravo", "JetBravo down"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo");
+
+        String actual = processor
+                .processAsyncFailSoft(services, messages, "QUOTE_UNAVAILABLE")
+                .join();
+        String expected = "QUOTE_UNAVAILABLE QUOTE_UNAVAILABLE";
+
+        logExpectedActual(reporter, "failSoft_allFail", expected, actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("FailSoft Liveness: hanging service gets fallback after timeout")
+    void failSoft_liveness_timeout(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                hangingService("StuckAir"),
+                new Microservice("JetBravo"));
+        List<String> messages = List.of("nyc-lax", "nyc-sfo");
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
+            String actual = processor
+                    .processAsyncFailSoft(services, messages, "QUOTE_UNAVAILABLE")
+                    .join();
+            String expected = "QUOTE_UNAVAILABLE JetBravo:NYC-SFO";
+            logExpectedActual(reporter, "failSoft_liveness_timeout", expected, actual);
+            assertEquals(expected, actual);
+        });
+    }
+
+    @Test
+    @DisplayName("CompletionOrder: all airline quotes returned, order may vary")
+    void completionOrder_observed_notFixed(TestReporter reporter) {
+        List<Microservice> services = List.of(
+                new Microservice("AirAlpha"),
+                new Microservice("JetBravo"),
+                new Microservice("SkyCharlie"));
+
+        List<String> expectedMembers = List.of("AirAlpha:NYC-LAX", "JetBravo:NYC-LAX", "SkyCharlie:NYC-LAX");
+
+        for (int i = 0; i < 8; i++) {
+            List<String> actual = processor.processAsyncCompletionOrder(services, "nyc-lax").join();
+            logExpectedActual(reporter, "completionOrder_run_" + (i + 1), expectedMembers, actual);
+            assertEquals(3, actual.size());
+            assertTrue(actual.contains("AirAlpha:NYC-LAX"));
+            assertTrue(actual.contains("JetBravo:NYC-LAX"));
+            assertTrue(actual.contains("SkyCharlie:NYC-LAX"));
+        }
+    }
+
+    private Microservice failingService(String serviceId, String errorMessage) {
+        return new Microservice(serviceId) {
+            @Override
+            public CompletableFuture<String> retrieveAsync(String input) {
+                CompletableFuture<String> cf = new CompletableFuture<>();
+                cf.completeExceptionally(new RuntimeException(errorMessage));
+                return cf;
+            }
+        };
+    }
+
+    private Microservice hangingService(String serviceId) {
+        return new Microservice(serviceId) {
+            @Override
+            public CompletableFuture<String> retrieveAsync(String input) {
+                return new CompletableFuture<>(); // never completes
+            }
+        };
+    }
+
+    private Throwable rootCause(Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null) {
+            cur = cur.getCause();
+        }
+        return cur;
+    }
+
+    private void logExpectedActual(TestReporter reporter, String testName, Object expected, Object actual) {
+        reporter.publishEntry("test", testName);
+        reporter.publishEntry("expected", String.valueOf(expected));
+        reporter.publishEntry("actual", String.valueOf(actual));
+        System.out.println("[TEST OUTPUT] " + testName + " expected=[" + expected + "] actual=[" + actual + "]");
+    }
+}


### PR DESCRIPTION
Summary
This PR updates AsyncProcessor failure-policy behavior and adds a dedicated airline-context test suite aligned with assignment requirements.

What changed
- Updated src/main/java/AsyncProcessor.java
- Added per-service timeout handling via timedRetrieve(...).orTimeout(...)
- Applied timeout retrieval to fail-fast, fail-partial, fail-soft, and completion-order paths
- Kept size-mismatch contract with `IllegalArgumentException` failed futures

- Added `src/test/java/AsyncProcessor_Airline_Test.java`
  - Fail-Fast semantics:
    - success aggregation
    - exception propagation on service failure
    - size mismatch behavior
  - Fail-Partial semantics:
    - all success
    - partial results on failures
    - all-fail empty list behavior
  - Fail-Soft semantics:
    - fallback substitution on failures
    - all-fail fallback behavior
  - Liveness:
    - hanging service scenarios validated with `assertTimeoutPreemptively(...)`
  - Nondeterminism:
    - completion order observed across repeated runs
    - no fixed-order assertions
  - Added expected vs actual logging in tests

- Updated `src/test/java/AsyncProcessor_Test.java`
  - Added completion-order nondeterminism check to legacy suite

Requirement mapping
- All futures awaited with timeouts: implemented
- Tests verify policy semantics: implemented
- Fail-Fast propagation: covered
- Fail-Partial partial return: covered
- Fail-Soft fallback behavior: covered
- Liveness (no infinite wait): covered
- Nondeterminism observed, not asserted: covered

Validation result
- `AsyncProcessor_Airline_Test`: 13 tests, 0 failures, 0 errors

Notes
- No Mockito used
- Public method signatures preserved
- Existing legacy test file (given in tutorial, but slightly modified since no mockito must be used) retained for backward compatibility and additional coverage